### PR TITLE
Refactor eventterm creation to include event

### DIFF
--- a/app/DoctrineMigrations/Version20170830112602.php
+++ b/app/DoctrineMigrations/Version20170830112602.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170830112602 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event CHANGE event_term event_term DATETIME DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE event CHANGE event_term event_term DATETIME NOT NULL');
+    }
+}

--- a/src/HcsOmot/SocialCalendar/CalendarBundle/Controller/EventTermController.php
+++ b/src/HcsOmot/SocialCalendar/CalendarBundle/Controller/EventTermController.php
@@ -2,6 +2,7 @@
 
 namespace HcsOmot\SocialCalendar\CalendarBundle\Controller;
 
+use HcsOmot\SocialCalendar\CalendarBundle\Entity\Event;
 use HcsOmot\SocialCalendar\CalendarBundle\Entity\EventTerm;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
@@ -35,16 +36,19 @@ class EventTermController extends Controller
     /**
      * Creates a new eventTerm entity.
      *
-     * @Route("/new", name="eventterm_new")
+     * @Route("/new/{id}", name="eventterm_new")
      * @Method({"GET", "POST"})
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request, Event $event)
     {
         $eventTerm = new Eventterm();
+        $eventTerm->setEvent($event);
         $form      = $this->createForm('HcsOmot\SocialCalendar\CalendarBundle\Form\EventTermType', $eventTerm);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $eventTerm->setTermProposer($this->getUser());
+            $eventTerm->addTermVoter($this->getUser());
             $em = $this->getDoctrine()->getManager();
             $em->persist($eventTerm);
             $em->flush();

--- a/src/HcsOmot/SocialCalendar/CalendarBundle/Entity/Event.php
+++ b/src/HcsOmot/SocialCalendar/CalendarBundle/Entity/Event.php
@@ -50,7 +50,7 @@ class Event
      *
      * @var \DateTime
      *
-     * @ORM\Column(name="event_term", type="datetime")
+     * @ORM\Column(name="event_term", type="datetime", nullable=true)
      */
     private $eventTerm;
 

--- a/src/HcsOmot/SocialCalendar/CalendarBundle/Form/EventTermType.php
+++ b/src/HcsOmot/SocialCalendar/CalendarBundle/Form/EventTermType.php
@@ -13,7 +13,7 @@ class EventTermType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('term')->add('termScore')->add('event');
+        $builder->add('term');
     }
 
     /**

--- a/src/HcsOmot/SocialCalendar/CalendarBundle/Form/EventType.php
+++ b/src/HcsOmot/SocialCalendar/CalendarBundle/Form/EventType.php
@@ -13,7 +13,7 @@ class EventType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name')->add('description')->add('venue')->add('eventTerm');
+        $builder->add('name')->add('description')->add('venue');
     }
 
     /**


### PR DESCRIPTION
WIP: add Event reference to EventTerm creation 

modified eventterm creation route to require the event id reference, removed event dropdown from eventterm form, added automatic +1 vote and term proposer on new term creation.  

TODO: 
- clean up forms and controllers (move automatic event insertion from controller into eventterm's form hidden field)
- add voters (for access controll)
- decouple entities from forms (use DTOs to get rid of setters on entities)?

